### PR TITLE
Resolution for Issue #73 -- Returning Report ID through API.

### DIFF
--- a/src/Http/Controllers/Api/Projects/ProjectReportController.php
+++ b/src/Http/Controllers/Api/Projects/ProjectReportController.php
@@ -31,17 +31,22 @@ class ProjectReportController extends Controller
      *
      * @param StoreProjectReport $request
      * @param int $id Project ID
+     * 
+     * @return mixed
      */
     public function store(StoreProjectReport $request, $id)
     {
         $report = new Report;
         $report->source()->associate($request->project);
         $report->type_id = $request->input('type_id');
+        $report->notify_when_ready = $request->getUser() == null;
         $report->user()->associate($request->user());
         $report->options = $request->getOptions($request);
         $report->save();
 
         $queue = config('reports.generate_report_queue');
         GenerateReportJob::dispatch($report)->onQueue($queue);
+
+        return $report;
     }
 }

--- a/src/Http/Controllers/Api/Volumes/VolumeReportController.php
+++ b/src/Http/Controllers/Api/Volumes/VolumeReportController.php
@@ -33,17 +33,22 @@ class VolumeReportController extends Controller
      *
      * @param StoreVolumeReport $request
      * @param int $id Volume ID
+     * 
+     * @return mixed
      */
     public function store(StoreVolumeReport $request, $id)
     {
         $report = new Report;
         $report->source()->associate($request->volume);
         $report->type_id = $request->input('type_id');
+        $report->notify_when_ready = $request->getUser() == null;
         $report->user()->associate($request->user());
         $report->options = $request->getOptions();
         $report->save();
 
         $queue = config('reports.generate_report_queue');
         GenerateReportJob::dispatch($report)->onQueue($queue);
+
+        return $report;
     }
 }

--- a/src/Jobs/GenerateReportJob.php
+++ b/src/Jobs/GenerateReportJob.php
@@ -40,6 +40,9 @@ class GenerateReportJob extends Job implements ShouldQueue
         $this->report->generate();
         $this->report->ready_at = new Carbon;
         $this->report->save();
-        $this->report->user->notify(new ReportReady($this->report));
+        
+        if ($this->report->notify_when_ready) {
+            $this->report->user->notify(new ReportReady($this->report));
+        }
     }
 }

--- a/src/Jobs/GenerateReportJob.php
+++ b/src/Jobs/GenerateReportJob.php
@@ -40,7 +40,7 @@ class GenerateReportJob extends Job implements ShouldQueue
         $this->report->generate();
         $this->report->ready_at = new Carbon;
         $this->report->save();
-        
+
         if ($this->report->notify_when_ready) {
             $this->report->user->notify(new ReportReady($this->report));
         }

--- a/src/Report.php
+++ b/src/Report.php
@@ -29,6 +29,7 @@ class Report extends Model
         'source_id' => 'int',
         'options' => 'array',
         'ready_at' => 'datetime',
+        'notify_when_ready' => 'boolean',
     ];
 
     /**

--- a/src/Report.php
+++ b/src/Report.php
@@ -29,7 +29,7 @@ class Report extends Model
         'source_id' => 'int',
         'options' => 'array',
         'ready_at' => 'datetime',
-        'notify_when_ready' => 'boolean',
+        'notify_when_ready' => 'bool',
     ];
 
     /**
@@ -164,4 +164,5 @@ class Report extends Model
     {
         Storage::disk(config('reports.storage_disk'))->delete($this->id);
     }
+
 }

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -18,5 +18,6 @@ $factory->define(Biigle\Modules\Reports\Report::class, function ($faker) {
             return factory(Biigle\Volume::class)->create()->id;
         },
         'source_type' => Biigle\Volume::class,
+        'notify_when_ready' => boolean,
     ];
 });

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -18,6 +18,5 @@ $factory->define(Biigle\Modules\Reports\Report::class, function ($faker) {
             return factory(Biigle\Volume::class)->create()->id;
         },
         'source_type' => Biigle\Volume::class,
-        'notify_when_ready' => boolean,
     ];
 });

--- a/src/database/migrations/2021_10_02_004819_add_notify_to_reports.php
+++ b/src/database/migrations/2021_10_02_004819_add_notify_to_reports.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNotifyToReports extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reports', function (Blueprint $table) {
+            $table->boolean('notify_when_ready')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reports', function (Blueprint $table) {
+            $table->dropColumn('notify_when_ready');
+        });
+    }
+}

--- a/tests/Jobs/GenerateReportJobTest.php
+++ b/tests/Jobs/GenerateReportJobTest.php
@@ -12,7 +12,7 @@ use TestCase;
 
 class GenerateReportJobTest extends TestCase
 {
-    public function testHandle()
+    public function testHandleNotify()
     {
         $report = Mockery::mock(Report::class);
         $report->shouldReceive('generate')->once();
@@ -22,6 +22,24 @@ class GenerateReportJobTest extends TestCase
         $report->shouldReceive('setAttribute')
             ->once()
             ->with('ready_at', Mockery::type(Carbon::class));
+        $report->shouldReceive('notify_when_ready')->set('notify_when_ready', true);
+        $report->shouldReceive('getAttribute')->with('notify_when_ready')->andReturn(true);
+        $report->shouldReceive('save')->once();
+        with(new GenerateReportJob($report))->handle();
+    }
+    
+    public function testHandleNoNotify()
+    {
+        $report = Mockery::mock(Report::class);
+        $report->shouldReceive('generate')->once();
+        $user = Mockery::mock(User::class);
+        $user->shouldNotReceive('notify'); // The user should not receive a notification if notify_when_ready is false.
+        $report->shouldReceive('getAttribute')->with('user')->andReturn($user);
+        $report->shouldReceive('setAttribute')
+            ->once()
+            ->with('ready_at', Mockery::type(Carbon::class));
+        $report->shouldReceive('notify_when_ready')->set('notify_when_ready', false);
+        $report->shouldReceive('getAttribute')->with('notify_when_ready')->andReturn(false);
         $report->shouldReceive('save')->once();
         with(new GenerateReportJob($report))->handle();
     }


### PR DESCRIPTION
Updates to allow suppression of email notification when reports are requested from the API by adding a persistable `notify_when_ready` attribute to the Report object.

Possible problem: the isAutomatedRequest method checks the ajax, wantsJson and getUser return values to determine whether the request is automatic, but in my testing, json and ajax are true and user is null when a request is made from the UI; and json and ajax are false and user is not null when a request is made from the API. So the user object is checked to make the determination, as isAutomatedRequest always returns true.

Pull request includes a migration and test for both possible values of notify_when_ready.