### PR TITLE
Add attrs to video annotation report

### DIFF
--- a/src/Support/Reports/Volumes/VideoAnnotations/CsvReportGenerator.php
+++ b/src/Support/Reports/Volumes/VideoAnnotations/CsvReportGenerator.php
@@ -200,6 +200,7 @@ class CsvReportGenerator extends VolumeReportGenerator
                 'users.lastname',
                 'videos.id as video_id',
                 'videos.filename as video_filename',
+                'videos.attrs',
                 'shapes.id as shape_id',
                 'shapes.name as shape_name',
                 'video_annotations.points',
@@ -240,6 +241,7 @@ class CsvReportGenerator extends VolumeReportGenerator
             'frames',
             'annotation_id',
             'created_at',
+            'attributes',
         ]);
 
         foreach ($rows as $row) {
@@ -259,6 +261,7 @@ class CsvReportGenerator extends VolumeReportGenerator
                 $row->frames,
                 $row->annotation_id,
                 $row->created_at,
+                $row->attrs,
             ]);
         }
 

--- a/src/resources/views/manual/tutorials/reports-schema.blade.php
+++ b/src/resources/views/manual/tutorials/reports-schema.blade.php
@@ -357,6 +357,12 @@ Animalia
             </li>
             <li><strong>Video annotation ID</strong></li>
             <li><strong>Creation date (of the video annotation label)</strong></li>
+            <li>
+                <strong>Additional attributes of the video</strong>
+                <p>
+                    The additional attributes of the video are encoded as a JSON object. The content may vary depending on the BIIGLE modules that are installed and the available metadata for the video. (e.g. MIME type, size, width and height).
+                </p>
+            </li>
         </ol>
 
         <h3><a name="video-label-reports"></a>Video label reports</h3>

--- a/tests/Support/Reports/Volumes/VideoAnnotations/CsvReportGeneratorTest.php
+++ b/tests/Support/Reports/Volumes/VideoAnnotations/CsvReportGeneratorTest.php
@@ -37,6 +37,7 @@ class CsvReportGeneratorTest extends TestCase
         'frames',
         'annotation_id',
         'created_at',
+        'attributes',
     ];
 
     public function testProperties()
@@ -66,6 +67,7 @@ class CsvReportGeneratorTest extends TestCase
 
         $al = VideoAnnotationLabelTest::create(['label_id' => $child->id]);
         $al->annotation->video_id = $video->id;
+        $al->annotation->video->attrs = $video->attrs;
         $al->annotation->save();
 
         $mock = Mockery::mock();
@@ -96,6 +98,7 @@ class CsvReportGeneratorTest extends TestCase
                 json_encode($al->annotation->frames),
                 $al->annotation->id,
                 $al->created_at,
+                json_encode($video->attrs),
             ]);
 
         $mock->shouldReceive('close')
@@ -174,6 +177,7 @@ class CsvReportGeneratorTest extends TestCase
                 json_encode($annotation->frames),
                 $annotation->id,
                 $al1->created_at,
+                json_encode($video->attrs),
             ]);
 
         $mock->shouldReceive('put')
@@ -194,6 +198,7 @@ class CsvReportGeneratorTest extends TestCase
                 json_encode($annotation->frames),
                 $annotation->id,
                 $al2->created_at,
+                json_encode($video->attrs),
             ]);
 
         $mock->shouldReceive('close')
@@ -282,6 +287,7 @@ class CsvReportGeneratorTest extends TestCase
                 json_encode($annotation->frames),
                 $annotation->id,
                 $al1->created_at,
+                json_encode($video->attrs),
             ]);
 
         $mock->shouldReceive('put')
@@ -302,6 +308,7 @@ class CsvReportGeneratorTest extends TestCase
                 json_encode($annotation->frames),
                 $annotation->id,
                 $al2->created_at,
+                json_encode($video->attrs),
             ]);
 
         $mock->shouldReceive('close')
@@ -484,6 +491,7 @@ class CsvReportGeneratorTest extends TestCase
                 json_encode($annotation->frames),
                 $annotation->id,
                 $al1->created_at,
+                json_encode($video->attrs),
             ]);
 
             $mock->shouldReceive('put')
@@ -504,6 +512,7 @@ class CsvReportGeneratorTest extends TestCase
                 json_encode($annotation->frames),
                 $annotation->id,
                 $al2->created_at,
+                json_encode($video->attrs),
             ]);
 
         $mock->shouldReceive('close')->once();


### PR DESCRIPTION
References #120

Add the attributes column to video annotation CSV report, in order to access video metadata (like width and height) from report.