### PR TITLE
Converts rectangles to polygon

### DIFF
--- a/src/resources/scripts/to_coco.py
+++ b/src/resources/scripts/to_coco.py
@@ -85,6 +85,10 @@ def annotation(row):
         circlePolygon = rotate(circlePolygon, angle, use_radians=True)
         desired_array = numpy.array(
             list(zip(*circlePolygon.exterior.coords.xy))).flatten().astype(float).tolist()
+    # convert Rectangle to Polygon
+    elif row.shape_name == "Rectangle":
+        # Rectangle only has 4 points as it does not close the polygon. Add the first point again so that it gets closed
+        desired_array.extend(desired_array[:2])
 
     # x = even  - start at the beginning at take every second item
     x_coord = desired_array[::2]


### PR DESCRIPTION
Closes #130
This MR makes rectangles polygons, as before only 4 points were considered in the segmentation.
To test this, create a rectangle shaped annotation with the tool, and generate a report for the image. You should see that in the segmentation part, are 10 elements -> 5 points.
